### PR TITLE
Introducing a new GameBoyJoyPadEvent to make it possible to inject keycodes without array lookup.

### DIFF
--- a/js/GameBoyIO.js
+++ b/js/GameBoyIO.js
@@ -355,18 +355,19 @@ function GameBoyEmulatorPlaying() {
 }
 function GameBoyKeyDown(key) {
 	if (GameBoyEmulatorInitialized() && GameBoyEmulatorPlaying()) {
-		var keycode = matchKey(key);
+		GameBoyJoyPadEvent(matchKey(key), true);
+	}
+}
+function GameBoyJoyPadEvent(keycode, down) {
+	if (GameBoyEmulatorInitialized() && GameBoyEmulatorPlaying()) {
 		if (keycode >= 0 && keycode < 8) {
-			gameboy.JoyPadEvent(keycode, true);
+			gameboy.JoyPadEvent(keycode, down);
 		}
 	}
 }
 function GameBoyKeyUp(key) {
 	if (GameBoyEmulatorInitialized() && GameBoyEmulatorPlaying()) {
-		var keycode = matchKey(key);
-		if (keycode >= 0 && keycode < 8) {
-			gameboy.JoyPadEvent(keycode, false);
-		}
+		GameBoyJoyPadEvent(matchKey(key), false);
 	}
 }
 function GameBoyGyroSignalHandler(e) {


### PR DESCRIPTION
One of a few small PRs designed to make it possible to un-branch the version of GameBoy-Online used in https://github.com/jbmorley/gameplay.
