### PR TITLE
Fix audio pops when loading rom and switching between tabs by ramping gain

### DIFF
--- a/js/other/XAudioServer.js
+++ b/js/other/XAudioServer.js
@@ -204,7 +204,29 @@ XAudioServer.prototype.initializeWebAudio = function () {
         XAudioJSWebAudioAudioNode = XAudioJSWebAudioContextHandle.createJavaScriptNode(XAudioJSSamplesPerCallback, 0, XAudioJSChannelsAllocated);	//Create the js event node.
     }
     XAudioJSWebAudioAudioNode.onaudioprocess = XAudioJSWebAudioEvent;																			//Connect the audio processing event to a handling function so we can manipulate output
-    XAudioJSWebAudioAudioNode.connect(XAudioJSWebAudioContextHandle.destination);																//Send and chain the output of the audio manipulation to the system audio output.
+    var gainNode = XAudioJSWebAudioContextHandle.createGain();
+    XAudioJSWebAudioAudioNode.connect(gainNode); //Connect the audio processing event to a handling function so we can manipulate output
+    gainNode.connect(XAudioJSWebAudioContextHandle.destination);
+    gainNode.gain.value = 0.001;
+    gainNode.gain.exponentialRampToValueAtTime(
+      1,
+      XAudioJSWebAudioContextHandle.currentTime + 0.5
+    );
+  
+    document.addEventListener("visibilitychange", function(event) {
+      if (document.hidden) {
+        gainNode.gain.exponentialRampToValueAtTime(
+          0.0001,
+          XAudioJSWebAudioContextHandle.currentTime + 0.5
+        );
+      } else {
+        gainNode.gain.exponentialRampToValueAtTime(
+          1,
+          XAudioJSWebAudioContextHandle.currentTime + 0.5
+        );
+      }
+    });
+    
     this.resetCallbackAPIAudioBuffer(XAudioJSWebAudioContextHandle.sampleRate);
     this.audioType = 1;
     /*


### PR DESCRIPTION
I had a look into the issue I raised at https://github.com/taisel/GameBoy-Online/issues/21 and came across this article http://alemangui.github.io/blog//2015/12/26/ramp-to-value.html which suggested using the web audio exponentialRampToValueAtTime function which I've added when the audio is first being set up and also when the visibility of the page changes (from switching tab). This seems to help quite a lot. I've only tested on Chrome as I'm using my fork in an Electron app. Hopefully this is useful.